### PR TITLE
✨ Feature - Expo Notification Test

### DIFF
--- a/FarmHan/App.js
+++ b/FarmHan/App.js
@@ -1,5 +1,65 @@
+import * as Notifications from "expo-notifications";
+import * as Device from "expo-device";
 import Navigation from "./Navigation";
 
 export default function App() {
-  return <Navigation />;
+    // // Expo 푸시 알림 설정 및 권한 요청
+    // const [expoPushToken, setExpoPushToken] = useState("");
+    // const [notification, setNotification] = useState(false);
+    // const notificationListener = useRef();
+    // const responseListener = useRef();
+
+    // useEffect(() => {
+    //     registerForPushNotificationsAsync().then((token) => setExpoPushToken(token));
+
+    //     // 앱이 포그라운드에 있을 때 수신한 알림 처리
+    //     notificationListener.current = Notifications.addNotificationReceivedListener((notification) => {
+    //         setNotification(notification);
+    //     });
+
+    //     // 사용자가 알림을 탭했을 때 처리
+    //     responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
+    //         console.log(response);
+    //     });
+
+    //     return () => {
+    //         Notifications.removeNotificationSubscription(notificationListener.current);
+    //         Notifications.removeNotificationSubscription(responseListener.current);
+    //     };
+    // }, []);
+
+    //// Expo 푸시 토큰 서버로 전송
+    // const sendPushTokenToServer = async (token) => {
+    //     await fetch("https://your-server.com/store-token", {
+    //         method: "POST",
+    //         headers: {
+    //             "Content-Type": "application/json",
+    //         },
+    //         body: JSON.stringify({ token }),
+    //     });
+    // };
+
+    return <Navigation />;
 }
+
+// async function registerForPushNotificationsAsync() {
+//     let token;
+//     if (Device.isDevice) {
+//         const { status: existingStatus } = await Notifications.getPermissionsAsync();
+//         let finalStatus = existingStatus;
+//         if (existingStatus !== "granted") {
+//             const { status } = await Notifications.requestPermissionsAsync();
+//             finalStatus = status;
+//         }
+//         if (finalStatus !== "granted") {
+//             alert("Failed to get push token for push notification!");
+//             return;
+//         }
+//         token = (await Notifications.getExpoPushTokenAsync()).data;
+//         console.log(token);
+//     } else {
+//         alert("Must use physical device for Push Notifications");
+//     }
+
+//     return token;
+// }

--- a/FarmHan/Navigation.js
+++ b/FarmHan/Navigation.js
@@ -1,4 +1,5 @@
-import React from "react";
+import * as Notifications from "expo-notifications";
+import React, { useEffect } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { NavigationContainer } from "@react-navigation/native";
 
@@ -21,6 +22,24 @@ function StackScreen() {
 }
 
 const Navigation = () => {
+    // 푸쉬 알림 권한 설정
+    Notifications.setNotificationHandler({
+        handleNotification: async () => ({
+            shouldShowAlert: true,
+            shouldPlaySound: false,
+            shouldSetBadge: false,
+        }),
+    });
+
+    useEffect(() => {
+        (async () => {
+            const { status } = await Notifications.requestPermissionsAsync();
+            if (status !== "granted") {
+                alert("알림 권한이 거부되었습니다!");
+            }
+        })();
+    }, []);
+
     return (
         <NavigationContainer>
             <StackScreen />

--- a/FarmHan/package-lock.json
+++ b/FarmHan/package-lock.json
@@ -14,6 +14,8 @@
         "@react-navigation/native-stack": "^6.11.0",
         "@react-navigation/stack": "^6.4.1",
         "expo": "~51.0.26",
+        "expo-device": "~6.0.2",
+        "expo-notifications": "~0.28.16",
         "expo-status-bar": "~1.12.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -3516,6 +3518,12 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -6548,6 +6556,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
@@ -6691,6 +6712,12 @@
         "babel-plugin-react-native-web": "~0.19.10",
         "react-refresh": "^0.14.2"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -8212,6 +8239,15 @@
         "expo": "bin/cli"
       }
     },
+    "node_modules/expo-application": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-5.9.1.tgz",
+      "integrity": "sha512-uAfLBNZNahnDZLRU41ZFmNSKtetHUT9Ua557/q189ua0AWV7pQjoVAx49E4953feuvqc9swtU3ScZ/hN1XO/FQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-10.0.10.tgz",
@@ -8237,6 +8273,41 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-device": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-6.0.2.tgz",
+      "integrity": "sha512-sCt91CuTmAuMXX4SlFOn4lIos2UIr8vb0jDstDDZXys6kErcj0uynC7bQAMreU5uRUTKMAl4MAMpKt9ufCXPBw==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^0.7.33"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-device/node_modules/ua-parser-js": {
+      "version": "0.7.38",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.38.tgz",
+      "integrity": "sha512-fYmIy7fKTSFAhG3fuPlubeGaMoAd6r0rSnfEsO5nEY55i26KSLt9EH7PLQiiqPUhNqYIJvSkTy1oArIcXAbPbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/expo-file-system": {
@@ -8398,6 +8469,61 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.28.16.tgz",
+      "integrity": "sha512-sj4oDip+uFNmxieGHkfS2Usrwbw2jfOTfQ22a7z5tdSo/vD6jWMlCHOnJifqYLjPxyqf9SLTsQWO3bmk7MY2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.5.0",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~5.9.0",
+        "expo-constants": "~16.0.0",
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/expo-status-bar": {
@@ -9356,6 +9482,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
@@ -9511,6 +9653,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -9563,6 +9720,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-negative-zero": {
@@ -11961,6 +12134,22 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -14916,6 +15105,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/FarmHan/package.json
+++ b/FarmHan/package.json
@@ -24,7 +24,9 @@
     "react-native-safe-area-context": "^4.10.8",
     "react-native-screens": "^3.34.0",
     "react-native-vector-icons": "^10.1.0",
-    "react-native-web": "~0.19.10"
+    "react-native-web": "~0.19.10",
+    "expo-notifications": "~0.28.16",
+    "expo-device": "~6.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/FarmHan/screens/SignIn.jsx
+++ b/FarmHan/screens/SignIn.jsx
@@ -1,8 +1,36 @@
+import * as Notifications from "expo-notifications";
 import { View, Text, TouchableOpacity, StyleSheet, TextInput } from "react-native";
-import React from "react";
+import React, { useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
 
 const SignIn = () => {
+    // 푸쉬 알림 테스트 코드
+    const sendNotification = async () => {
+        await Notifications.scheduleNotificationAsync({
+            content: {
+                title: "알림 제목 테스트입니다.",
+                body: "알림 내용 테스트입니다.",
+            },
+            trigger: null, // 즉시 보내려면 'trigger'에 'null'을 설정(시간을 지정하고 싶으면 숫자를 입력 => ex. 5분 == 300)
+            repeats: false, // 알림이 반복되지 않도록 설정
+        });
+    };
+
+    useEffect(() => {
+        sendNotification();
+
+        const subscription = Notifications.addNotificationReceivedListener((notification) => {
+            // 푸쉬 알림이 수신된 경우 이를 처리하는 코드
+            console.log("알림 전송 완료", notification);
+        });
+
+        return () => {
+            subscription.remove();
+        };
+    }, []);
+
+    // SignIn 화면에 들어오면 자동으로 푸쉬 알림이 발송됩니다.
+
     const navigation = useNavigation();
 
     const [id, setId] = React.useState("");


### PR DESCRIPTION
## 관련 이슈
- Resolves : #10 
 
## 작업 사항
- Expo Notification으로 로컬 알림을 보내는 임시 기능을 추가했습니다.
- Expo Notification으로 원격 알림을 보낼 수 있도록 하는 코드를 `App.js`에 추가했습니다.

## 참고 사항
- SignIn 페이지에 들어가게 되면 로컬 푸시 알림이 자동으로 전송됩니다.
- `Navigation.js`와 `SignIn.jsx`에 로컬 푸시 알림 코드를 테스트를 위해 임시로 작성해놓은 상태입니다.
- 현재 `App.js`에서 Expo 원격 푸시 알림 토큰을 받고 이를 서버 측으로 보내는 코드를 작성해놓은 상태입니다.
